### PR TITLE
Moved fsevents to optional dependency as it is not supported in linux platform

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,9 @@
     "react-native": "^0.62.2",
     "react-native-fs": "^2.16.6"
   },
+  "optionalDependencies" : {
+    "fsevents": "^1.2.13"
+  },
   "bugs": {
     "url": "https://github.com/achak1987/react-native-hlf-wrapper/issues"
   },
@@ -169,7 +172,6 @@
     "for-in": "^1.0.2",
     "find-cache-dir": "^2.1.0",
     "fs-extra": "^8.1.0",
-    "fsevents": "^1.2.13",
     "fragment-cache": "^0.2.1",
     "fs.realpath": "^1.0.0",
     "fresh": "^0.5.2",


### PR DESCRIPTION
**Moved "fsevents" to optional dependency as it is not supported in linux platform**

**Reference :** https://github.com/0xProject/0x-monorepo/issues/473#issuecomment-375267378

![Screenshot from 2020-06-04 15-45-39](https://user-images.githubusercontent.com/30879156/83764662-7eb16f80-a67a-11ea-9eaf-ba9ab43c9e04.png)
