### PR TITLE
Changed repository address to point to the migrated repository in bityoga organisation

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ let response = await HlfSdk.query(user, channelName, chaincodeName, fnc, args); 
 ```
 
 ### Testing up the example app associated with this project [Optional]
-+ navigate to the example folder under project: https://github.com/achak1987/react-native-hlf-wrapper
++ navigate to the example folder under project: https://github.com/bityoga/react-native-hlf-wrapper
 + connection_profile.template.json file is already copied here as connection_profile.json
 + change the connection_profile.json as per your hyperledger fabric configuration
 + Install dependencies

--- a/example/package.json
+++ b/example/package.json
@@ -13,7 +13,7 @@
     "react": "16.11.0",
     "react-native": "0.62.2",
     "react-native-fs": "^2.16.6",
-    "react-native-hlf-wrapper": "https://github.com/achak1987/react-native-hlf-wrapper"
+    "react-native-hlf-wrapper": "https://github.com/bityoga/react-native-hlf-wrapper"
   },
   "devDependencies": {
     "@babel/core": "^7.6.2",

--- a/example/yarn.lock
+++ b/example/yarn.lock
@@ -5086,9 +5086,9 @@ react-native-fs@^2.16.6:
     base-64 "^0.1.0"
     utf8 "^3.0.0"
 
-"react-native-hlf-wrapper@https://github.com/achak1987/react-native-hlf-wrapper":
+"react-native-hlf-wrapper@https://github.com/bityoga/react-native-hlf-wrapper":
   version "0.0.1"
-  resolved "https://github.com/achak1987/react-native-hlf-wrapper#6e0b28af230a00a15ea7bf005aa3f37cfb0f54bd"
+  resolved "https://github.com/bityoga/react-native-hlf-wrapper#6e0b28af230a00a15ea7bf005aa3f37cfb0f54bd"
   dependencies:
     abort-controller "^3.0.0"
     absolute-path "^0.0.0"

--- a/package.json
+++ b/package.json
@@ -9,8 +9,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/achak1987/react-native-hlf-wrapper.git",
-    "baseUrl": "https://github.com/achak1987/react-native-hlf-wrapper"
+    "url": "git+https://github.com/bityoga/react-native-hlf-wrapper.git",
+    "baseUrl": "https://github.com/bityoga/react-native-hlf-wrapper"
   },
   "keywords": [
     "react-native",
@@ -41,9 +41,9 @@
     "fsevents": "^1.2.13"
   },
   "bugs": {
-    "url": "https://github.com/achak1987/react-native-hlf-wrapper/issues"
+    "url": "https://github.com/bityoga/react-native-hlf-wrapper/issues"
   },
-  "homepage": "https://github.com/achak1987/react-native-hlf-wrapper#readme",
+  "homepage": "https://github.com/bityoga/react-native-hlf-wrapper#readme",
   "dependencies": {
     "absolute-path": "^0.0.0",
     "anser": "^1.4.9",


### PR DESCRIPTION
**Changed repository address to point to the migrated repository in bityoga organisation**

- In package.json  the  link to repository was pointing to "https://github.com/achak1987/react-native-hlf-wrapper.git"
- Now it is changed to point to  "https://github.com/bityoga/react-native-hlf-wrapper.git"